### PR TITLE
Show more than 1 game-schedule for a team in a day

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,36 +1,86 @@
-
 urls = [
-    {
-        // url: 'https://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-team-fixture.php?sp=25&g=404&s=8329&t=3730&embedded=',
-        url: 'https://m95pp3sq2c.execute-api.us-east-1.amazonaws.com/vball/short-cuts/',
-        container: '#container1'
-    },
-    {
-        //url: 'https://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-team-fixture.php?sp=25&g=405&s=8329&t=3513&embedded=',
-        url: 'https://m95pp3sq2c.execute-api.us-east-1.amazonaws.com/vball/hotline-bling/',
-        container: '#container2'
-    },
-    {
-        //url: 'https://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-team-fixture.php?sp=25&g=406&s=8329&t=3711&embedded=',
-        url: 'https://m95pp3sq2c.execute-api.us-east-1.amazonaws.com/vball/hotline/',
-        container: '#container3'
-    }
-]
+  {
+    // url: 'https://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-team-fixture.php?sp=25&g=404&s=8329&t=3730&embedded=',
+    url:
+      "https://m95pp3sq2c.execute-api.us-east-1.amazonaws.com/vball/short-cuts/",
+    container: "#container1"
+  },
+  {
+    //url: 'https://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-team-fixture.php?sp=25&g=405&s=8329&t=3513&embedded=',
+    url:
+      "https://m95pp3sq2c.execute-api.us-east-1.amazonaws.com/vball/hotline-bling/",
+    container: "#container2"
+  },
+  {
+    //url: 'https://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-team-fixture.php?sp=25&g=406&s=8329&t=3711&embedded=',
+    url:
+      "https://m95pp3sq2c.execute-api.us-east-1.amazonaws.com/vball/hotline/",
+    container: "#container3"
+  }
+];
+
+renderContent = (response, container, row) => {
+  // team name
+  $(container)
+    .find(".team-name")
+    .text(
+      $(response)
+        .find("#content > h1")
+        .text()
+    );
+  // opponent
+  $(container)
+    .find(".opp-team")
+    .text(
+      $(response)
+        .find(`#ladder ${row} td:nth-child(2)`)
+        .text()
+    );
+  // day
+  $(container)
+    .find(".day")
+    .text(
+      $(response)
+        .find(`#ladder ${row} td:nth-child(3)`)
+        .text() +
+        ", " +
+        $(response)
+          .find(`#ladder ${row} td:nth-child(4)`)
+          .text()
+    );
+  // time
+  $(container)
+    .find(".time")
+    .text(
+      $(response)
+        .find(`#ladder ${row} td:nth-child(5)`)
+        .text()
+    );
+  // court
+  $(container)
+    .find(".court")
+    .text(
+      $(response)
+        .find(`#ladder ${row} td:nth-child(6)`)
+        .text()
+    );
+};
 
 urls.forEach(function(url) {
-    $.get(url, function(response){
-        // team name
-        $(url.container).find('.team-name').text($(response).find('#content > h1').text())
-        // opponent
-        $(url.container).find('.opp-team').text($(response).find('#ladder tr:nth-child(2) td:nth-child(2)').text())
-        // day
-        $(url.container).find('.day').text($(response).find('#ladder tr:nth-child(2) td:nth-child(3)').text() + ', ' + $(response).find('#ladder tr:nth-child(2) td:nth-child(4)').text())
-        // time
-        $(url.container).find('.time').text($(response).find('#ladder tr:nth-child(2) td:nth-child(5)').text())
-        // court
-        $(url.container).find('.court').text($(response).find('#ladder tr:nth-child(2) td:nth-child(6)').text())
-    })  
-})
+  $.get(url, function(response) {
+    rowCount = $(response)
+      .find("#ladder")
+      .find("tr").length;
 
+    renderContent(response, $(url.container), "tr:nth-child(2)");
 
-
+    if (rowCount > 3) {
+      container = $(url.container)
+        .clone()
+        .appendTo("main");
+      renderContent(response, container, "tr:nth-child(3)");
+    } else {
+      return;
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
             <p>Day: <span class="day"></span></p>
             <p>Time: <span class="time"></span></p>
             <p>Court: <span class="court"></span></p>
-            <a target="_blank" class="ladder" href="http://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-ladder.php?s=8329&sp=25&g=404&t=3730&embedded="> -- view ladder -- </a>
+            <a target="_blank" class="ladder" href="http://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-ladder.php?sp=25&g=443&s=8329&embedded="> -- view ladder -- </a>
         </div>
 
         <div id="container2">
@@ -31,7 +31,7 @@
             <p>Day: <span class="day"></span></p>
             <p>Time: <span class="time"></span></p>
             <p>Court: <span class="court"></span></p>
-            <a target="_blank" class="ladder" href="http://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-ladder.php?s=8329&sp=25&g=405&t=3513&embedded="> -- view ladder -- </a>
+            <a target="_blank" class="ladder" href="http://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-ladder.php?sp=25&g=444&s=8329&embedded="> -- view ladder -- </a>
         </div>
 
         <div id="container3">
@@ -41,7 +41,7 @@
             <p>Day: <span class="day"></span></p>
             <p>Time: <span class="time"></span></p>
             <p>Court: <span class="court"></span></p>
-            <a target="_blank" class="ladder" href="http://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-ladder.php?s=8329&sp=25&g=406&t=3711&embedded="> -- view ladder -- </a>
+            <a target="_blank" class="ladder" href="http://results.sportskeepglobal.com/vic--sandstorm-altona/stadium-ladder.php?sp=25&g=444&s=8329&embedded="> -- view ladder -- </a>
         </div>
     </main>
 


### PR DESCRIPTION
BEFORE:
- it would only show 1 game schedule for a team (whether or not there are more than 1 games scheduled).

It should now show both schedules. I didn't really bother with creating a loop as it's highly unlikely that we'd have a team that's scheduled to play more than twice in a night. 